### PR TITLE
Update CI actions for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,16 +13,33 @@ jobs:
     environment: Production
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Gitleaks
-        uses: gitleaks/gitleaks-action@v2
+      - name: Install Gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_CONFIG: .gitleaks.toml
+          GH_TOKEN: ${{ github.token }}
           GITLEAKS_VERSION: 8.30.0
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp -d)"
+          gh release download "v${GITLEAKS_VERSION}" \
+            --repo gitleaks/gitleaks \
+            --pattern "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            --pattern "gitleaks_${GITLEAKS_VERSION}_checksums.txt" \
+            --dir "$tmp"
+          (
+            cd "$tmp"
+            grep "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz$" "gitleaks_${GITLEAKS_VERSION}_checksums.txt" | sha256sum -c -
+            tar -xzf "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks
+          )
+          mkdir -p "$RUNNER_TEMP/gitleaks-bin"
+          install -m 0755 "$tmp/gitleaks" "$RUNNER_TEMP/gitleaks-bin/gitleaks"
+          echo "$RUNNER_TEMP/gitleaks-bin" >> "$GITHUB_PATH"
+
+      - name: Gitleaks
+        run: gitleaks detect --redact --config .gitleaks.toml --source . --platform github
 
       - name: Check image variants
         env:
@@ -46,7 +63,7 @@ jobs:
           "$tmp/devimg" check --config devimg.toml
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm
@@ -77,10 +94,10 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
           cache: npm


### PR DESCRIPTION
## Summary
- update checkout and setup-node to Node 24-compatible action versions
- replace the Node 20-based Gitleaks Action with a pinned Gitleaks CLI install and redacted scan
- keep devimg check, lint, typecheck, build, and deploy behavior unchanged

## Verification
- workflow YAML parse
- gitleaks detect --redact --config .gitleaks.toml --source . --platform github --no-banner
- npm run format:check
- npm run lint
- npm run typecheck
- npm run build
- precommit checks