### PR TITLE
Check devimg manifest export drift in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             exit 0
           fi
           tmp="$(mktemp -d)"
-          GH_TOKEN="$DEVIMG_RELEASE_TOKEN" gh release download v0.1.5 \
+          GH_TOKEN="$DEVIMG_RELEASE_TOKEN" gh release download v0.1.6 \
             --repo cleissonom/devimg \
             --pattern 'devimg-linux-x86_64.tar.gz*' \
             --dir "$tmp"
@@ -61,6 +61,13 @@ jobs:
             tar -xzf devimg-linux-x86_64.tar.gz
           )
           "$tmp/devimg" check --config devimg.toml
+          "$tmp/devimg" manifest export \
+            --manifest public/images/devimg-manifest.json \
+            --strip-prefix public \
+            --url-prefix / \
+            --format typescript \
+            --output lib/devimg.generated.ts \
+            --check
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/docs/devimg.md
+++ b/docs/devimg.md
@@ -23,6 +23,7 @@ The CLI Tools artwork uses a `[[overrides]]` entry with `fit = "contain"` so the
 devimg optimize --config devimg.toml --dry-run
 devimg optimize --config devimg.toml
 devimg manifest export --manifest public/images/devimg-manifest.json --strip-prefix public --url-prefix / --format typescript --output lib/devimg.generated.ts
+devimg manifest export --manifest public/images/devimg-manifest.json --strip-prefix public --url-prefix / --format typescript --output lib/devimg.generated.ts --check
 devimg check --config devimg.toml
 ```
 
@@ -30,6 +31,6 @@ Use `--allow-overwrite` when intentionally regenerating existing variants after 
 
 ## CI
 
-The main CI workflow can run `devimg check` by downloading the Linux `v0.1.5` release archive from the private `cleissonom/devimg` repository. Configure a `DEVIMG_RELEASE_TOKEN` repository secret with read access to that repository to enable the check. Without the secret, CI skips only the image check and continues with lint, typecheck, and build.
+The main CI workflow can run `devimg check` and `devimg manifest export --check` by downloading the Linux `v0.1.6` release archive from the private `cleissonom/devimg` repository. Configure a `DEVIMG_RELEASE_TOKEN` repository secret with read access to that repository to enable the check. Without the secret, CI skips only the image check and continues with lint, typecheck, and build.
 
-Generated variants and `public/images/devimg-manifest.json` should be committed with image changes; `.devimg/` is ignored because reports are regenerated locally and in CI.
+Generated variants, `public/images/devimg-manifest.json`, and `lib/devimg.generated.ts` should be committed with image changes; `.devimg/` is ignored because reports are regenerated locally and in CI.


### PR DESCRIPTION
## Summary
- download devimg v0.1.6 in website CI
- run `devimg manifest export --check` after `devimg check`
- document the committed generated helper drift check

## Verification
- `devimg v0.1.6 check --config devimg.toml`
- `devimg v0.1.6 manifest export --manifest public/images/devimg-manifest.json --strip-prefix public --url-prefix / --format typescript --output lib/devimg.generated.ts --check`
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `gitleaks detect --redact --config .gitleaks.toml --source . --platform github --no-banner`
- `git diff --check`