### PR TITLE
Update DevImg CI to v0.1.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             exit 0
           fi
           tmp="$(mktemp -d)"
-          GH_TOKEN="$DEVIMG_RELEASE_TOKEN" gh release download v0.1.9 \
+          GH_TOKEN="$DEVIMG_RELEASE_TOKEN" gh release download v0.1.10 \
             --repo cleissonom/devimg \
             --pattern 'devimg-linux-x86_64.tar.gz*' \
             --dir "$tmp"

--- a/docs/devimg.md
+++ b/docs/devimg.md
@@ -31,6 +31,6 @@ Use `--allow-overwrite` when intentionally regenerating existing variants after 
 
 ## CI
 
-The main CI workflow can run `devimg check` and `devimg manifest export --check` by downloading the Linux `v0.1.6` release archive from the private `cleissonom/devimg` repository. Configure a `DEVIMG_RELEASE_TOKEN` repository secret with read access to that repository to enable the check. Without the secret, CI skips only the image check and continues with lint, typecheck, and build.
+The main CI workflow can run `devimg check` and `devimg manifest export --check` by downloading the Linux `v0.1.10` release archive from the private `cleissonom/devimg` repository and verifying its checksum. Configure a `DEVIMG_RELEASE_TOKEN` repository secret with read access to that repository to enable the check. Without the secret, CI skips only the image check and continues with lint, typecheck, and build.
 
 Generated variants, `public/images/devimg-manifest.json`, and `lib/devimg.generated.ts` should be committed with image changes; `.devimg/` is ignored because reports are regenerated locally and in CI.


### PR DESCRIPTION
## Summary
- update website CI to download private DevImg release `v0.1.10`
- update DevImg docs to match the pinned release and checksum verification flow

## Context
This keeps `cleisson.com` on the same DevImg release that was just stabilized and published. The CI still uses the existing private GitHub Release binary download plus `.sha256` verification and `DEVIMG_RELEASE_TOKEN`; it does not change image config, generated assets, app code, or deployment behavior.

## Verification
- verified Linux and macOS ARM `v0.1.10` release checksums
- downloaded `devimg 0.1.10`
- `devimg check --config devimg.toml`
- `devimg manifest export --manifest public/images/devimg-manifest.json --strip-prefix public --url-prefix / --format typescript --output lib/devimg.generated.ts --check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run format:check`
- YAML parse for `.github/workflows/ci.yml`
- Docker `actionlint`
- `gitleaks detect --redact --config .gitleaks.toml --source .`
- `git diff --check`
- precommit hook: staged gitleaks + lint-staged/prettier

## Notes
`devimg check` passes. It still reports advisory crop warnings for AccessTrace card/banner variants; those are existing warnings and not release blockers. They were captured in DevImg's local next-steps notes as future warning-management ergonomics input.
