### PR TITLE
[codex] Update DevImg CI to v0.1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
             exit 0
           fi
           tmp="$(mktemp -d)"
-          GH_TOKEN="$DEVIMG_RELEASE_TOKEN" gh release download v0.1.11 \
+          GH_TOKEN="$DEVIMG_RELEASE_TOKEN" gh release download v0.1.12 \
             --repo cleissonom/devimg \
             --pattern 'devimg-linux-x86_64.tar.gz*' \
             --dir "$tmp"

--- a/docs/devimg.md
+++ b/docs/devimg.md
@@ -33,6 +33,6 @@ Use `--allow-overwrite` when intentionally regenerating existing variants after 
 
 ## CI
 
-The main CI workflow can run `devimg check --fail-on-warning` and `devimg manifest export --check` by downloading the Linux `v0.1.11` release archive from the private `cleissonom/devimg` repository and verifying its checksum. Configure a `DEVIMG_RELEASE_TOKEN` repository secret with read access to that repository to enable the check. Without the secret, CI skips only the image check and continues with lint, typecheck, and build.
+The main CI workflow can run `devimg check --fail-on-warning` and `devimg manifest export --check` by downloading the Linux `v0.1.12` release archive from the private `cleissonom/devimg` repository and verifying its checksum. Configure a `DEVIMG_RELEASE_TOKEN` repository secret with read access to that repository to enable the check. Without the secret, CI skips only the image check and continues with lint, typecheck, and build.
 
 Generated variants, `public/images/devimg-manifest.json`, and `lib/devimg.generated.ts` should be committed with image changes; `.devimg/` is ignored because reports are regenerated locally and in CI.


### PR DESCRIPTION
## Summary

- Pin the website DevImg CI download to private release `v0.1.12`.
- Update `docs/devimg.md` so the documented CI release matches the workflow.
- Leave generated images, the manifest, and the TypeScript helper unchanged.

## Verification

- Downloaded `devimg-darwin-aarch64.tar.gz` from `cleissonom/devimg` release `v0.1.12` and verified its SHA-256 checksum.
- Ran downloaded `devimg 0.1.12`:
  - `devimg check --config devimg.toml --fail-on-warning`
  - `devimg manifest export --manifest public/images/devimg-manifest.json --strip-prefix public --url-prefix / --format typescript --output lib/devimg.generated.ts --check`
- `ruby -e 'require "yaml"; Dir[".github/**/*.yml", ".github/**/*.yaml"].sort.each { |path| YAML.load_file(path); puts "ok #{path}" }'`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color`
- `npm run lint`
- `npm run typecheck`
- `npm run format:check`
- `npm run build`
- `gitleaks detect --redact --config .gitleaks.toml --source . --no-banner`
- `git diff --check`
