### PR TITLE
[codex] Update DevImg project page

### DIFF
--- a/content/projects/en-US/devimg.md
+++ b/content/projects/en-US/devimg.md
@@ -1,7 +1,7 @@
 ---
 title: DevImg
 slug: devimg
-summary: Rust image pipeline and GitHub Action that optimizes project images, generates responsive variants, emits manifests and reports, and enforces image budgets in CI.
+summary: Rust CLI and GitHub Action that generates responsive frontend image variants, exports app helpers, creates review artifacts, and enforces freshness and budgets in CI.
 dateStart: "2026-05-01T12:00:00.000Z"
 role: Software Engineer
 status: active
@@ -25,29 +25,37 @@ links:
 coverImage: /projects/devimg.png
 highlights:
   - Built a Rust workspace with a reusable core library and a `devimg` CLI for repeatable image optimization workflows.
-  - Added content-hashed filenames, crop controls, preset overrides, generated manifest helpers, and CI drift checks for generated app mappings.
-  - Packaged the tool as a versioned GitHub Release and dogfooded it in this website's production image pipeline.
+  - Added content-hashed filenames, crop controls, preset overrides, generated manifest helpers, framework diagnostics, and static visual review artifacts.
+  - Dogfooded the workflow on this website with `devimg optimize`, `devimg manifest export`, `devimg check --fail-on-warning`, and a pinned GitHub Release binary.
 ---
 
-DevImg is a developer image pipeline built to make static website image workflows reproducible instead of manual.
+DevImg is a developer image pipeline built to make frontend image workflows reproducible, reviewable, and CI-enforced instead of manual.
 
-The tool reads a `devimg.toml` config, scans source folders, generates configured variants, writes a JSON manifest, produces a Markdown report, and checks that generated files are present, current, and inside configured budgets.
+The tool reads a `devimg.toml` config, scans source folders, generates configured variants, writes a JSON manifest, exports app-friendly helpers, produces a Markdown report, and checks that generated files are present, current, and inside configured budgets.
 
 ## What I built
 
 - Rust core library that owns config parsing, scanning, planning, transforms, manifests, reports, budgets, and check behavior.
-- Rust CLI with `init`, `optimize`, `check`, `report`, `inspect`, and manifest export commands.
+- Rust CLI with `init`, `optimize`, `check`, `doctor`, `report`, `inspect`, review artifact, and manifest export commands.
 - GitHub Action wrapper that can run the CLI in pull requests and fail when generated images are missing, stale, oversized, or out of sync.
 - Content-hashed output filenames for safe immutable caching.
 - Crop anchors, normalized focal points, and source-specific preset overrides for real-world screenshots and diagrams.
 - Generated TypeScript manifest export so web apps can consume hashed image paths without hand-maintained lookup tables.
+- Framework-aware `doctor` diagnostics that explain helper export checks and the intended `img`/`picture`, framework `Image`, or layered optimization consumption modes.
+- Static HTML review artifact so generated variants can be inspected locally or uploaded from CI.
 
 ## Why I built it
 
 The project started from smaller `imgconvert` and `imgcrop` ideas, then grew into a productized workflow for portfolio and static-site images.
 
-I wanted the pipeline to behave like normal developer infrastructure: deterministic config, repeatable output, explicit reports, CI enforcement, release assets, and real dogfooding in production.
+I wanted the pipeline to behave like normal developer infrastructure: deterministic config, repeatable output, explicit reports, CI enforcement, release assets, and real dogfooding in production. Generated images should be normal PR material: source/config changes, generated variants, manifest, helper export, report, and review artifact all move together.
+
+## Dogfood proof
+
+This website uses DevImg for project card and banner images. The source images live under `public/projects`, generated variants live under `public/images/generated`, and application code reads a checked-in TypeScript helper generated from the manifest.
+
+CI downloads a pinned private GitHub Release binary, verifies the checksum, runs strict `devimg check --fail-on-warning`, and validates that the helper export is up to date. That keeps Vercel deployments using checked-in static assets while still getting CDN-friendly content-hash filenames.
 
 ## Current scope
 
-DevImg currently focuses on local static assets and stable PNG, JPEG, and WebP workflows. It does not provide a hosted service, remote storage, automatic pull-request commits, or a web UI.
+DevImg currently focuses on local static assets and stable PNG, JPEG, WebP, and opt-in AVIF output workflows. It does not provide a hosted service, remote storage, automatic pull-request commits, AI automation, or a web UI.

--- a/content/projects/es-ES/devimg.md
+++ b/content/projects/es-ES/devimg.md
@@ -1,7 +1,7 @@
 ---
 title: DevImg
 slug: devimg
-summary: Pipeline de imágenes en Rust con GitHub Action para optimizar imágenes de proyectos, generar variantes responsivas, emitir manifiestos e informes, y validar presupuestos de imagen en CI.
+summary: CLI en Rust con GitHub Action para generar variantes responsivas de imágenes frontend, exportar helpers de la aplicación, crear artefactos de revisión y validar frescura y presupuesto en CI.
 dateStart: "2026-05-01T12:00:00.000Z"
 role: Ingeniero de Software
 status: active
@@ -25,29 +25,37 @@ links:
 coverImage: /projects/devimg.png
 highlights:
   - Construí un workspace Rust con una biblioteca core reutilizable y una CLI `devimg` para flujos repetibles de optimización de imágenes.
-  - Añadí nombres con hash de contenido, controles de recorte, overrides por preset, helpers generados desde el manifiesto y validación de drift en CI.
-  - Empaqueté la herramienta como GitHub Release versionado y la dogfoodeé en el pipeline de imágenes de producción de este sitio.
+  - Añadí nombres con hash de contenido, controles de recorte, overrides por preset, helpers generados desde el manifiesto, diagnósticos de framework y artefactos visuales de revisión.
+  - Probé el flujo en este sitio con `devimg optimize`, `devimg manifest export`, `devimg check --fail-on-warning` y un binario fijado de GitHub Release.
 ---
 
-DevImg es un pipeline de imágenes para desarrollo creado para que los flujos de imágenes en sitios estáticos sean reproducibles en lugar de manuales.
+DevImg es un pipeline de imágenes para desarrollo creado para que los flujos de imágenes frontend sean reproducibles, revisables y validados en CI en lugar de manuales.
 
-La herramienta lee un `devimg.toml`, escanea carpetas de origen, genera variantes configuradas, escribe un manifiesto JSON, produce un informe Markdown y valida que los archivos generados existan, estén actualizados y respeten los presupuestos configurados.
+La herramienta lee un `devimg.toml`, escanea carpetas de origen, genera variantes configuradas, escribe un manifiesto JSON, exporta helpers amigables para la aplicación, produce un informe Markdown y valida que los archivos generados existan, estén actualizados y respeten los presupuestos configurados.
 
 ## Qué construí
 
 - Biblioteca core en Rust responsable de configuración, escaneo, planificación, transformaciones, manifiestos, informes, presupuestos y validación.
-- CLI en Rust con comandos `init`, `optimize`, `check`, `report`, `inspect` y exportación de manifiesto.
+- CLI en Rust con comandos `init`, `optimize`, `check`, `doctor`, `report`, `inspect`, artefacto de revisión y exportación de manifiesto.
 - GitHub Action que ejecuta la CLI en pull requests y falla cuando las imágenes generadas faltan, están obsoletas, son demasiado grandes o están fuera de sincronía.
 - Nombres de archivo con hash de contenido para permitir cache inmutable de forma segura.
 - Anclas de recorte, puntos focales normalizados y overrides por archivo para screenshots y diagramas reales.
 - Exportación TypeScript del manifiesto para que las aplicaciones consuman rutas con hash sin tablas mantenidas manualmente.
+- Diagnósticos `doctor` conscientes de frameworks, explicando validación de helpers y los modos esperados de consumo con `img`/`picture`, componente `Image` del framework u optimización en capas.
+- Artefacto HTML estático de revisión para inspeccionar variantes generadas localmente o subidas desde CI.
 
 ## Por qué lo construí
 
 El proyecto empezó a partir de las ideas más pequeñas de `imgconvert` e `imgcrop`, y luego evolucionó hasta convertirse en un flujo productizado para imágenes de portafolios y sitios estáticos.
 
-Quería que el pipeline se comportara como infraestructura de desarrollo: configuración determinística, salida repetible, informes explícitos, validación en CI, artefactos de release y uso real en producción.
+Quería que el pipeline se comportara como infraestructura de desarrollo: configuración determinística, salida repetible, informes explícitos, validación en CI, artefactos de release y uso real en producción. Las imágenes generadas deberían aparecer en PRs como material normal de revisión: fuente/configuración, variantes generadas, manifiesto, helper exportado, informe y artefacto visual avanzando juntos.
+
+## Prueba en producción
+
+Este sitio usa DevImg para imágenes de tarjetas y banners de proyectos. Las imágenes de origen viven en `public/projects`, las variantes generadas viven en `public/images/generated` y el código de la aplicación lee un helper TypeScript versionado generado desde el manifiesto.
+
+El CI descarga un binario fijado desde una GitHub Release privada, verifica el checksum, ejecuta `devimg check --fail-on-warning` en modo estricto y confirma que el helper exportado está actualizado. Eso mantiene los despliegues en Vercel usando assets estáticos versionados, con nombres de archivo con hash de contenido compatibles con CDN.
 
 ## Alcance actual
 
-DevImg hoy se enfoca en assets estáticos locales y flujos estables con PNG, JPEG y WebP. Todavía no ofrece servicio alojado, almacenamiento remoto, commits automáticos en pull requests ni interfaz web.
+DevImg hoy se enfoca en assets estáticos locales y flujos estables con PNG, JPEG, WebP y salida AVIF opt-in. Todavía no ofrece servicio alojado, almacenamiento remoto, commits automáticos en pull requests, automatización con IA ni interfaz web.

--- a/content/projects/pt-BR/devimg.md
+++ b/content/projects/pt-BR/devimg.md
@@ -1,7 +1,7 @@
 ---
 title: DevImg
 slug: devimg
-summary: Pipeline de imagens em Rust com GitHub Action para otimizar imagens de projetos, gerar variantes responsivas, emitir manifestos e relatórios, e validar orçamentos de imagem no CI.
+summary: CLI em Rust com GitHub Action para gerar variantes responsivas de imagens frontend, exportar helpers da aplicação, criar artefatos de revisão e validar frescor e orçamento no CI.
 dateStart: "2026-05-01T12:00:00.000Z"
 role: Engenheiro de Software
 status: active
@@ -25,29 +25,37 @@ links:
 coverImage: /projects/devimg.png
 highlights:
   - Criei um workspace Rust com biblioteca core reutilizável e CLI `devimg` para fluxos repetíveis de otimização de imagens.
-  - Adicionei nomes com hash de conteúdo, controles de crop, overrides por preset, helpers gerados a partir do manifesto e validação de drift no CI.
-  - Empacotei a ferramenta como GitHub Release versionado e usei em produção no pipeline de imagens deste site.
+  - Adicionei nomes com hash de conteúdo, controles de crop, overrides por preset, helpers gerados a partir do manifesto, diagnósticos de framework e artefatos visuais de revisão.
+  - Usei o fluxo neste site com `devimg optimize`, `devimg manifest export`, `devimg check --fail-on-warning` e um binário fixado de GitHub Release.
 ---
 
-DevImg é um pipeline de imagens para desenvolvimento criado para tornar fluxos de imagens em sites estáticos mais reproduzíveis e menos manuais.
+DevImg é um pipeline de imagens para desenvolvimento criado para tornar fluxos de imagens frontend reproduzíveis, revisáveis e validados em CI em vez de manuais.
 
-A ferramenta lê um `devimg.toml`, escaneia pastas de origem, gera variantes configuradas, escreve um manifesto JSON, produz um relatório Markdown e valida se os arquivos gerados existem, estão atualizados e respeitam os orçamentos configurados.
+A ferramenta lê um `devimg.toml`, escaneia pastas de origem, gera variantes configuradas, escreve um manifesto JSON, exporta helpers amigáveis para a aplicação, produz um relatório Markdown e valida se os arquivos gerados existem, estão atualizados e respeitam os orçamentos configurados.
 
 ## O que construí
 
 - Biblioteca core em Rust responsável por configuração, scan, planejamento, transformações, manifestos, relatórios, orçamentos e validação.
-- CLI em Rust com comandos `init`, `optimize`, `check`, `report`, `inspect` e exportação de manifesto.
+- CLI em Rust com comandos `init`, `optimize`, `check`, `doctor`, `report`, `inspect`, artefato de revisão e exportação de manifesto.
 - GitHub Action que executa a CLI em pull requests e falha quando imagens geradas estão ausentes, antigas, grandes demais ou fora de sincronia.
 - Nomes de arquivos com hash de conteúdo para permitir cache imutável com segurança.
 - Âncoras de crop, pontos focais normalizados e overrides por arquivo para screenshots e diagramas reais.
 - Exportação TypeScript do manifesto para que aplicações consumam caminhos com hash sem tabelas mantidas manualmente.
+- Diagnósticos `doctor` cientes de frameworks, explicando validação de helpers e os modos esperados de consumo com `img`/`picture`, componente `Image` do framework ou otimização em camadas.
+- Artefato HTML estático de revisão para inspecionar variantes geradas localmente ou enviadas pelo CI.
 
 ## Por que construí
 
 O projeto começou a partir das ideias menores de `imgconvert` e `imgcrop`, depois evoluiu para um fluxo produtizado para imagens de portfólio e sites estáticos.
 
-Eu queria que o pipeline se comportasse como infraestrutura de desenvolvimento: configuração determinística, saída repetível, relatórios explícitos, validação em CI, artefatos de release e uso real em produção.
+Eu queria que o pipeline se comportasse como infraestrutura de desenvolvimento: configuração determinística, saída repetível, relatórios explícitos, validação em CI, artefatos de release e uso real em produção. Imagens geradas devem aparecer em PRs como material normal de revisão: fonte/configuração, variantes geradas, manifesto, helper exportado, relatório e artefato visual andando juntos.
+
+## Prova em produção
+
+Este site usa DevImg para imagens de cards e banners dos projetos. As imagens de origem ficam em `public/projects`, as variantes geradas ficam em `public/images/generated` e o código da aplicação lê um helper TypeScript versionado gerado a partir do manifesto.
+
+O CI baixa um binário fixado de uma GitHub Release privada, valida o checksum, executa `devimg check --fail-on-warning` em modo estrito e confirma que o helper exportado está atualizado. Isso mantém os deploys na Vercel usando assets estáticos versionados, com nomes de arquivo com hash de conteúdo compatíveis com CDN.
 
 ## Escopo atual
 
-DevImg hoje foca em assets estáticos locais e fluxos estáveis com PNG, JPEG e WebP. Ele ainda não oferece serviço hospedado, armazenamento remoto, commits automáticos em pull requests ou interface web.
+DevImg hoje foca em assets estáticos locais e fluxos estáveis com PNG, JPEG, WebP e saída AVIF opt-in. Ele ainda não oferece serviço hospedado, armazenamento remoto, commits automáticos em pull requests, automação por IA ou interface web.


### PR DESCRIPTION
## Summary

Updates the localized DevImg project page content to reflect the v0.1.13 public story:

- positions DevImg as a frontend image workflow with generated variants, helper exports, review artifacts, and CI checks;
- mentions framework diagnostics and static visual review artifacts;
- adds dogfood proof for cleisson.com using generated project card/banner images and checked-in TypeScript manifest helpers;
- keeps scope explicit: no hosted service, automatic PR commits, AI automation, or web UI.

## Verification

Already run locally before opening this PR:

```bash
npm run format:check -- content/projects/en-US/devimg.md content/projects/pt-BR/devimg.md content/projects/es-ES/devimg.md
npm run typecheck
npm run lint
npm run build
git diff --check
```

Precommit also ran on commit:

```bash
npm run precommit:secrets
lint-staged
```
